### PR TITLE
Fix outdated import path to AggregatorV3Interface.sol

### DIFF
--- a/FundMe.sol
+++ b/FundMe.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;
 
-import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol";
 import {PriceConverter} from "./PriceConverter.sol";
 
 error NotOwner();


### PR DESCRIPTION
The import path of AggregatorV3Interface.sol was outdated in FundMe.sol

updated to new path in Chainlink's Repo ->
"@chainlink/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol"